### PR TITLE
Update rand dependency to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.10.1"
 
 [[bench]]
 name = "encode_benchmark"

--- a/benches/decode_benchmark.rs
+++ b/benches/decode_benchmark.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use std::time::Instant;
 use erasure_coding::{Encoder, Decoder, Block};
 
@@ -7,7 +7,7 @@ const DATA_SHARD_COUNTS: [usize; 8] = [3, 7, 10, 30, 70, 100, 150, 200];
 const REPAIR_SHARD_COUNTS: [usize; 8] = [2, 2, 3, 5, 10, 10, 15, 20];
 
 fn black_box(value: u64) {
-    if value == rand::thread_rng().gen() {
+    if value == rand::rng().random() {
         println!("{}", value);
     }
 }
@@ -18,7 +18,7 @@ fn benchmark(shard_size: u16) -> u64 {
         let elements = data_shards * shard_size as usize;
         let mut data: Vec<u8> = vec![0; elements];
         for i in 0..elements {
-            data[i] = rand::thread_rng().gen();
+            data[i] = rand::rng().random();
         }
 
         let iterations = TARGET_TOTAL_BYTES / elements;
@@ -28,7 +28,7 @@ fn benchmark(shard_size: u16) -> u64 {
         for _ in 0..iterations {
             let mut erased: Vec<Option<Block>> = data_blocks.iter().map(|x| Some(x.clone())).collect();
             for _ in 0..*repair_shards {
-                let i = rand::thread_rng().gen_range(0, *data_shards);
+                let i = rand::rng().random_range(0..*data_shards);
                 erased[i] = None;
             }
             erased_datas.push(erased);

--- a/benches/encode_benchmark.rs
+++ b/benches/encode_benchmark.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use std::time::Instant;
 use erasure_coding::Encoder;
 
@@ -7,7 +7,7 @@ const DATA_SHARD_COUNTS: [usize; 8] = [3, 7, 10, 30, 70, 100, 150, 200];
 const REPAIR_SHARD_COUNTS: [usize; 8] = [2, 2, 3, 5, 10, 10, 15, 20];
 
 fn black_box(value: u64) {
-    if value == rand::thread_rng().gen() {
+    if value == rand::rng().random() {
         println!("{}", value);
     }
 }
@@ -20,7 +20,7 @@ fn main() {
         let elements = data_shards * shard_size as usize;
         let mut data: Vec<u8> = vec![0; elements];
         for i in 0..elements {
-            data[i] = rand::thread_rng().gen();
+            data[i] = rand::rng().random();
         }
 
         let now = Instant::now();

--- a/src/gf256.rs
+++ b/src/gf256.rs
@@ -1593,7 +1593,7 @@ impl Polynomial {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
 
     use crate::gf256::{Octet, fused_addassign_mul_scalar, mulassign_scalar};
     use crate::gf256::Polynomial;
@@ -1603,10 +1603,10 @@ mod tests {
     #[test]
     fn polynomial_mul() {
         let octet = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         let octet2 = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         let poly = Polynomial {
             coefficients: vec![octet.clone(), octet2.clone()]
@@ -1618,7 +1618,7 @@ mod tests {
     #[test]
     fn addition() {
         let octet = Octet {
-            value: rand::thread_rng().gen(),
+            value: rand::rng().random(),
         };
         // See section 5.7.2. u is its own additive inverse
         assert_eq!(Octet::zero(), &octet + &octet);
@@ -1627,7 +1627,7 @@ mod tests {
     #[test]
     fn multiplication_identity() {
         let octet = Octet {
-            value: rand::thread_rng().gen(),
+            value: rand::rng().random(),
         };
         assert_eq!(octet, &octet * &Octet::one());
     }
@@ -1635,7 +1635,7 @@ mod tests {
     #[test]
     fn multiplicative_inverse() {
         let octet = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         let one = Octet::one();
         assert_eq!(one, &octet * &(&one / &octet));
@@ -1644,7 +1644,7 @@ mod tests {
     #[test]
     fn division() {
         let octet = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         assert_eq!(Octet::one(), &octet / &octet);
     }
@@ -1671,11 +1671,11 @@ mod tests {
     #[test]
     fn mul_assign_simd() {
         let size = 41;
-        let scalar = Octet::new(rand::thread_rng().gen_range(1, 255));
+        let scalar = Octet::new(rand::rng().random_range(1..255));
         let mut data1: Vec<u8> = vec![0; size];
         let mut expected: Vec<u8> = vec![0; size];
         for i in 0..size {
-            data1[i] = rand::thread_rng().gen();
+            data1[i] = rand::rng().random();
             expected[i] = (&Octet::new(data1[i]) * &scalar).byte();
         }
 
@@ -1687,13 +1687,13 @@ mod tests {
     #[test]
     fn fma_simd() {
         let size = 41;
-        let scalar = Octet::new(rand::thread_rng().gen_range(1, 255));
+        let scalar = Octet::new(rand::rng().random_range(1..255));
         let mut data1: Vec<u8> = vec![0; size];
         let mut data2: Vec<u8> = vec![0; size];
         let mut expected: Vec<u8> = vec![0; size];
         for i in 0..size {
-            data1[i] = rand::thread_rng().gen();
-            data2[i] = rand::thread_rng().gen();
+            data1[i] = rand::rng().random();
+            data2[i] = rand::rng().random();
             expected[i] = (Octet::new(data1[i]) + &Octet::new(data2[i]) * &scalar).byte();
         }
 


### PR DESCRIPTION
Migrate API usage to rand 0.10.1:
- Replace `use rand::Rng` with `use rand::RngExt`
- Replace `thread_rng().gen()` with `rng().random()`
- Replace `thread_rng().gen_range(low, high)` with `rng().random_range(low..high)`

https://claude.ai/code/session_012Efe3uCN3ywtwKx7eEJect