### PR TITLE
Update CI workflow to use latest actions and explicit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,26 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test


### PR DESCRIPTION
## Summary
Updated the GitHub Actions CI workflow to use the latest action versions and restructured the build steps to run formatting, linting, and testing as explicit commands rather than through deprecated action wrappers.

## Key Changes
- **Action Updates:**
  - Upgraded `actions/checkout` from v2 to v4
  - Replaced `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable` (more actively maintained)
  - Removed `actions-rs/cargo@v1` in favor of direct `run` commands

- **Workflow Improvements:**
  - Added `push` trigger for the master branch (in addition to pull requests)
  - Updated runner from `ubuntu-20.04` to `ubuntu-latest` for better maintainability
  - Separated build steps into three explicit commands:
    - `cargo fmt --all -- --check` for formatting validation
    - `cargo clippy --all-targets -- -D warnings` for linting with warnings as errors
    - `cargo test` for running tests

- **Configuration Simplification:**
  - Removed redundant `toolchain: stable` configuration (now handled by the rust-toolchain action)
  - Moved `components` configuration to the new toolchain action

## Benefits
- Uses actively maintained action versions
- More transparent CI steps with explicit commands
- Stricter linting enforcement with `-D warnings` flag
- CI now runs on both push to master and pull requests

https://claude.ai/code/session_01Uruv9aFfrQcdA5dyiEhaRY