### PR TITLE
Update rand crate API usage to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.10.1"
 
 [[bench]]
 name = "encode_benchmark"

--- a/benches/decode_benchmark.rs
+++ b/benches/decode_benchmark.rs
@@ -1,5 +1,5 @@
 use erasure_coding::{Block, Decoder, Encoder};
-use rand::Rng;
+use rand::RngExt;
 use std::time::Instant;
 
 const TARGET_TOTAL_BYTES: usize = 128 * 1024 * 1024;
@@ -7,7 +7,7 @@ const DATA_SHARD_COUNTS: [usize; 8] = [3, 7, 10, 30, 70, 100, 150, 200];
 const REPAIR_SHARD_COUNTS: [usize; 8] = [2, 2, 3, 5, 10, 10, 15, 20];
 
 fn black_box(value: u64) {
-    if value == rand::thread_rng().gen() {
+    if value == rand::rng().random() {
         println!("{}", value);
     }
 }
@@ -18,7 +18,7 @@ fn benchmark(shard_size: u16) -> u64 {
         let elements = data_shards * shard_size as usize;
         let mut data: Vec<u8> = vec![0; elements];
         for item in data.iter_mut() {
-            *item = rand::thread_rng().gen();
+            *item = rand::rng().random();
         }
 
         let iterations = TARGET_TOTAL_BYTES / elements;
@@ -29,7 +29,7 @@ fn benchmark(shard_size: u16) -> u64 {
             let mut erased: Vec<Option<Block>> =
                 data_blocks.iter().map(|x| Some(x.clone())).collect();
             for _ in 0..*repair_shards {
-                let i = rand::thread_rng().gen_range(0, *data_shards);
+                let i = rand::rng().random_range(0..*data_shards);
                 erased[i] = None;
             }
             erased_datas.push(erased);

--- a/benches/encode_benchmark.rs
+++ b/benches/encode_benchmark.rs
@@ -1,5 +1,5 @@
 use erasure_coding::Encoder;
-use rand::Rng;
+use rand::RngExt;
 use std::time::Instant;
 
 const TARGET_TOTAL_BYTES: usize = 128 * 1024 * 1024;
@@ -7,7 +7,7 @@ const DATA_SHARD_COUNTS: [usize; 8] = [3, 7, 10, 30, 70, 100, 150, 200];
 const REPAIR_SHARD_COUNTS: [usize; 8] = [2, 2, 3, 5, 10, 10, 15, 20];
 
 fn black_box(value: u64) {
-    if value == rand::thread_rng().gen() {
+    if value == rand::rng().random() {
         println!("{}", value);
     }
 }
@@ -20,7 +20,7 @@ fn main() {
         let elements = data_shards * shard_size as usize;
         let mut data: Vec<u8> = vec![0; elements];
         for item in data.iter_mut() {
-            *item = rand::thread_rng().gen();
+            *item = rand::rng().random();
         }
 
         let now = Instant::now();

--- a/src/gf256.rs
+++ b/src/gf256.rs
@@ -1599,7 +1599,7 @@ impl Polynomial {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
 
     use crate::gf256::Polynomial;
     use crate::gf256::OCT_EXP;
@@ -1609,10 +1609,10 @@ mod tests {
     #[test]
     fn polynomial_mul() {
         let octet = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         let octet2 = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         let poly = Polynomial {
             coefficients: vec![octet.clone(), octet2.clone()],
@@ -1624,7 +1624,7 @@ mod tests {
     #[test]
     fn addition() {
         let octet = Octet {
-            value: rand::thread_rng().gen(),
+            value: rand::rng().random(),
         };
         // See section 5.7.2. u is its own additive inverse
         assert_eq!(Octet::zero(), &octet + &octet);
@@ -1633,7 +1633,7 @@ mod tests {
     #[test]
     fn multiplication_identity() {
         let octet = Octet {
-            value: rand::thread_rng().gen(),
+            value: rand::rng().random(),
         };
         assert_eq!(octet, &octet * &Octet::one());
     }
@@ -1641,7 +1641,7 @@ mod tests {
     #[test]
     fn multiplicative_inverse() {
         let octet = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         let one = Octet::one();
         assert_eq!(one, &octet * &(&one / &octet));
@@ -1650,7 +1650,7 @@ mod tests {
     #[test]
     fn division() {
         let octet = Octet {
-            value: rand::thread_rng().gen_range(1, 255),
+            value: rand::rng().random_range(1..255),
         };
         assert_eq!(Octet::one(), &octet / &octet);
     }
@@ -1677,11 +1677,11 @@ mod tests {
     #[test]
     fn mul_assign_simd() {
         let size = 41;
-        let scalar = Octet::new(rand::thread_rng().gen_range(1, 255));
+        let scalar = Octet::new(rand::rng().random_range(1..255));
         let mut data1: Vec<u8> = vec![0; size];
         let mut expected: Vec<u8> = vec![0; size];
         for i in 0..size {
-            data1[i] = rand::thread_rng().gen();
+            data1[i] = rand::rng().random();
             expected[i] = (&Octet::new(data1[i]) * &scalar).byte();
         }
 
@@ -1693,13 +1693,13 @@ mod tests {
     #[test]
     fn fma_simd() {
         let size = 41;
-        let scalar = Octet::new(rand::thread_rng().gen_range(1, 255));
+        let scalar = Octet::new(rand::rng().random_range(1..255));
         let mut data1: Vec<u8> = vec![0; size];
         let mut data2: Vec<u8> = vec![0; size];
         let mut expected: Vec<u8> = vec![0; size];
         for i in 0..size {
-            data1[i] = rand::thread_rng().gen();
-            data2[i] = rand::thread_rng().gen();
+            data1[i] = rand::rng().random();
+            data2[i] = rand::rng().random();
             expected[i] = (Octet::new(data1[i]) + &Octet::new(data2[i]) * &scalar).byte();
         }
 


### PR DESCRIPTION
## Summary
Updates the codebase to use the rand 0.10.1 API, replacing deprecated methods with their modern equivalents across tests and benchmarks.

## Key Changes
- **Import changes**: Replaced `use rand::Rng` with `use rand::RngExt` to use the new trait-based API
- **RNG instantiation**: Changed `rand::thread_rng()` calls to `rand::rng()` for the new global RNG interface
- **Range generation**: Updated `gen_range(a, b)` to `random_range(a..b)` with exclusive upper bound syntax
- **Random value generation**: Changed `gen()` to `random()` for generating random values
- **Affected files**:
  - `src/gf256.rs`: Updated all test functions (polynomial_mul, addition, multiplication_identity, multiplicative_inverse, division, mul_assign_simd, fma_simd)
  - `benches/decode_benchmark.rs`: Updated benchmark code
  - `benches/encode_benchmark.rs`: Updated benchmark code
  - `Cargo.toml`: Updated rand dependency from 0.7 to 0.10.1

## Implementation Details
The changes align with rand 0.10.x's API redesign which:
- Introduces `RngExt` trait for extension methods
- Provides a simpler `rand::rng()` function for thread-local RNG access
- Uses range syntax (`a..b`) instead of tuple arguments for `random_range()`
- Renames `gen()` to `random()` for clarity

https://claude.ai/code/session_01XubC1ConKKdyhxfYJLx4xB